### PR TITLE
  Add '-out' flag to 'dep status' command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ validate: build licenseok
 	./hack/validate-vendor.bash
 	./hack/validate-licence.bash
 
-test:
+test: build
 	./hack/test.bash
 
 install: build

--- a/hack/test.bash
+++ b/hack/test.bash
@@ -15,3 +15,18 @@ IMPORT_DURING_SOLVE=${IMPORT_DURING_SOLVE:-false}
 go test -race \
     -ldflags '-X github.com/golang/dep/cmd/dep.flagImportDuringSolve=${IMPORT_DURING_SOLVE}' \
     ./...
+
+if ! ./dep status -out .dep.status.file.output; then exit 1; fi
+if ! ./dep status > .dep.status.stdout.output; then
+   rm -f .dep.status.file.output
+   exit 1
+fi
+if ! diff .dep.status.file.output .dep.status.stdout.output; then
+  diffResult=1
+else
+  diffResult=0
+fi
+rm -f .dep.status.file.output .dep.status.stdout.output
+if [ "$diffResult" -eq "1" ]; then
+  exit 1
+fi


### PR DESCRIPTION
  * Added '-out' flag to 'dep status' command.
  * The new flag accepts a single argument. Users can mention
    the file path where the status output should be written to.
  * Blank values are ignored.
  * When a file path is specified, the status output will be
    written to a file at the specified file path. If the file
    cannot be created (for some reason), a meaningful error
    message will be printed on the stdout.

  Tests:
  - dep status -?
    Shows the information about the new -out flag
  - dep status -out junk/file/path
    A meaningful error is printed
  - dep status -out proper/file/path
    The status output is printed to the file at the
    mentioned file path.

<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?

<!--

fixes #
fixes #

-->
