### PR TITLE
Enhance dep status to support detailed output

### DIFF
--- a/cmd/dep/status.go
+++ b/cmd/dep/status.go
@@ -7,6 +7,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -14,9 +15,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"sort"
 	"strings"
-	"sync"
 	"text/tabwriter"
 	"text/template"
 
@@ -24,6 +23,8 @@ import (
 	"github.com/golang/dep/gps"
 	"github.com/golang/dep/gps/paths"
 	"github.com/pkg/errors"
+	"sort"
+	"sync"
 )
 
 const availableTemplateVariables = "ProjectRoot, Constraint, Version, Revision, Latest, and PackageCount."
@@ -102,6 +103,7 @@ func (cmd *statusCommand) Register(fs *flag.FlagSet) {
 	fs.BoolVar(&cmd.old, "old", false, "only show out-of-date dependencies")
 	fs.BoolVar(&cmd.missing, "missing", false, "only show missing dependencies")
 	fs.StringVar(&cmd.outFilePath, "out", "", "path to a file to which to write the output. Blank value will be ignored")
+	fs.BoolVar(&cmd.detail, "detail", false, "include more detail in the chosen format")
 }
 
 type statusCommand struct {
@@ -113,12 +115,16 @@ type statusCommand struct {
 	old         bool
 	missing     bool
 	outFilePath string
+	detail   bool
 }
 
 type outputter interface {
 	BasicHeader() error
 	BasicLine(*BasicStatus) error
 	BasicFooter() error
+	DetailHeader(*dep.SolveMeta) error
+	DetailLine(*DetailStatus) error
+	DetailFooter(*dep.SolveMeta) error
 	MissingHeader() error
 	MissingLine(*MissingStatus) error
 	MissingFooter() error
@@ -151,6 +157,29 @@ func (out *tableOutput) BasicLine(bs *BasicStatus) error {
 		formatVersion(bs.Revision),
 		bs.getConsolidatedLatest(shortRev),
 		bs.PackageCount,
+	)
+	return err
+}
+
+func (out *tableOutput) DetailHeader(metadata *dep.SolveMeta) error {
+	_, err := fmt.Fprintf(out.w, "PROJECT\tSOURCE\tCONSTRAINT\tVERSION\tREVISION\tLATEST\tPKGS USED\n")
+	return err
+}
+
+func (out *tableOutput) DetailFooter(metadata *dep.SolveMeta) error {
+	return out.BasicFooter()
+}
+
+func (out *tableOutput) DetailLine(ds *DetailStatus) error {
+	_, err := fmt.Fprintf(out.w,
+		"%s\t%s\t%s\t%s\t%s\t%s\t[%s]\t\n",
+		ds.ProjectRoot,
+		ds.Source,
+		ds.getConsolidatedConstraint(),
+		formatVersion(ds.Version),
+		formatVersion(ds.Revision),
+		ds.getConsolidatedLatest(shortRev),
+		strings.Join(ds.Packages,", "),
 	)
 	return err
 }
@@ -196,6 +225,7 @@ func (out *tableOutput) OldFooter() error {
 type jsonOutput struct {
 	w       io.Writer
 	basic   []*rawStatus
+	detail  []rawDetailProject
 	missing []*MissingStatus
 	old     []*rawOldStatus
 }
@@ -211,6 +241,25 @@ func (out *jsonOutput) BasicFooter() error {
 
 func (out *jsonOutput) BasicLine(bs *BasicStatus) error {
 	out.basic = append(out.basic, bs.marshalJSON())
+	return nil
+}
+
+func (out *jsonOutput) DetailHeader(metadata *dep.SolveMeta) error {
+	out.detail = []rawDetailProject{}
+	return nil
+}
+
+func (out *jsonOutput) DetailFooter(metadata *dep.SolveMeta) error {
+	doc := rawDetail{
+		Projects: out.detail,
+		Metadata: newRawMetadata(metadata),
+	}
+
+	return json.NewEncoder(out.w).Encode(doc)
+}
+
+func (out *jsonOutput) DetailLine(ds *DetailStatus) error {
+	out.detail = append(out.detail, *ds.marshalJSON())
 	return nil
 }
 
@@ -272,6 +321,18 @@ func (out *dotOutput) BasicLine(bs *BasicStatus) error {
 	return nil
 }
 
+func (out *dotOutput) DetailHeader(metadata *dep.SolveMeta) error {
+	return out.BasicHeader()
+}
+
+func (out *dotOutput) DetailFooter(metadata *dep.SolveMeta) error {
+	return out.BasicFooter()
+}
+
+func (out *dotOutput) DetailLine(ds *DetailStatus) error {
+	return out.BasicLine(&ds.BasicStatus)
+}
+
 func (out *dotOutput) MissingHeader() error                { return nil }
 func (out *dotOutput) MissingLine(ms *MissingStatus) error { return nil }
 func (out *dotOutput) MissingFooter() error                { return nil }
@@ -291,6 +352,29 @@ func (out *templateOutput) BasicLine(bs *BasicStatus) error {
 		Revision:     bs.Revision.String(),
 		Latest:       bs.getConsolidatedLatest(shortRev),
 		PackageCount: bs.PackageCount,
+	}
+	return out.tmpl.Execute(out.w, data)
+}
+
+// TODO: Enhance
+func (out *templateOutput) DetailHeader(metadata *dep.SolveMeta) error {
+	return out.BasicHeader()
+}
+
+// TODO: Enhance
+func (out *templateOutput) DetailFooter(metadata *dep.SolveMeta) error {
+	return out.BasicFooter()
+}
+
+func (out *templateOutput) DetailLine(ds *DetailStatus) error {
+	data := rawDetailProject{
+		ProjectRoot:  ds.ProjectRoot,
+		Constraint:   ds.getConsolidatedConstraint(),
+		Locked:       formatDetailVersion(ds.Version, ds.Revision),
+		Latest:       formatDetailLatestVersion(ds.Latest, ds.hasError),
+		PackageCount: ds.PackageCount,
+		Source:       ds.Source,
+		Packages:     ds.Packages,
 	}
 	return out.tmpl.Execute(out.w, data)
 }
@@ -377,7 +461,7 @@ func (cmd *statusCommand) Run(ctx *dep.Ctx, args []string) error {
 		return err
 	}
 
-	hasMissingPkgs, errCount, err := runStatusAll(ctx, out, p, sm)
+	hasMissingPkgs, errCount, err := cmd.runStatusAll(ctx, out, p, sm)
 	if err != nil {
 		switch err {
 		case errFailedUpdate:
@@ -430,6 +514,10 @@ func (cmd *statusCommand) validateFlags() error {
 
 	if cmd.missing {
 		opModes = append(opModes, "-missing")
+	}
+
+	if cmd.detail {
+		opModes = append(opModes, "-detail")
 	}
 
 	// Check if any other flags are passed with -dot.
@@ -602,30 +690,46 @@ type rawStatus struct {
 // rawDetail is is additional information used for the status when the
 // -detail flag is specified
 type rawDetail struct {
-	Projects []rawDetailProject `json:"projects,omitempty"`
-	Metadata rawDetailMetadata  `json:"metadata,omitempty"`
+	Projects []rawDetailProject
+	Metadata rawDetailMetadata
 }
 
 type rawDetailVersion struct {
-	Revision string `json:"revision,omitempty"`
-	Version  string `json:"version,omitempty"`
-	Branch   string `json:"branch,omitempty"`
+	Revision string `json:"Revision,omitempty"`
+	Version  string `json:"Version,omitempty"`
+	Branch   string `json:"Branch,omitempty"`
 }
 
 type rawDetailProject struct {
-	ProjectRoot string           `json:"project-root,omitempty"`
-	Packages    []string         `json:"packages,omitempty"`
-	Locked      rawDetailVersion `json:"locked,omitempty"`
-	Latest      rawDetailVersion `json:"latest,omitempty"`
-	Source      string           `json:"source,omitempty"`
+	ProjectRoot string
+	Packages    []string
+	Locked      rawDetailVersion
+	Latest      rawDetailVersion
+	Source      string `json:"Source,omitempty"`
+	Constraint   string
+	PackageCount int
 }
 
 type rawDetailMetadata struct {
-	AnalyzerName    string `json:"analyzer-name,omitempty"`
-	AnalyzerVersion int    `json:"analyzer-version,omitempty"`
-	InputsDigest    string `json:"inputs-digest,omitempty"`
-	SolverName      string `json:"solver-name,omitempty"`
-	SolverVersion   int    `json:"solver-version,omitempty"`
+	AnalyzerName    string
+	AnalyzerVersion int
+	InputsDigest    string
+	SolverName      string
+	SolverVersion   int
+}
+
+func newRawMetadata(metadata *dep.SolveMeta) rawDetailMetadata {
+	if metadata == nil {
+		return rawDetailMetadata{}
+	}
+
+	return rawDetailMetadata{
+		AnalyzerName:    metadata.AnalyzerName,
+		AnalyzerVersion: metadata.AnalyzerVersion,
+		InputsDigest:    hex.EncodeToString(metadata.InputsDigest),
+		SolverName:      metadata.SolverName,
+		SolverVersion:   metadata.SolverVersion,
+	}
 }
 
 // BasicStatus contains all the information reported about a single dependency
@@ -640,6 +744,15 @@ type BasicStatus struct {
 	PackageCount int
 	hasOverride  bool
 	hasError     bool
+}
+
+// DetailStatus contains all information reported about a single dependency
+// in the detailed status output mode. The included information matches the
+// information included about a a project in a lock file.
+type DetailStatus struct {
+	BasicStatus
+	Packages []string
+	Source   string
 }
 
 func (bs *BasicStatus) getConsolidatedConstraint() string {
@@ -696,13 +809,27 @@ func (bs *BasicStatus) marshalJSON() *rawStatus {
 	}
 }
 
+func (ds *DetailStatus) marshalJSON() *rawDetailProject {
+	rawStatus := ds.BasicStatus.marshalJSON()
+
+	return &rawDetailProject{
+		ProjectRoot:  rawStatus.ProjectRoot,
+		Constraint:   rawStatus.Constraint,
+		Locked:       formatDetailVersion(ds.Version, ds.Revision),
+		Latest:       formatDetailLatestVersion(ds.Latest, ds.hasError),
+		Source:       ds.Source,
+		Packages:     ds.Packages,
+		PackageCount: ds.PackageCount,
+	}
+}
+
 // MissingStatus contains information about all the missing packages in a project.
 type MissingStatus struct {
 	ProjectRoot     string
 	MissingPackages []string
 }
 
-func runStatusAll(ctx *dep.Ctx, out outputter, p *dep.Project, sm gps.SourceManager) (hasMissingPkgs bool, errCount int, err error) {
+func (cmd *statusCommand) runStatusAll(ctx *dep.Ctx, out outputter, p *dep.Project, sm gps.SourceManager) (hasMissingPkgs bool, errCount int, err error) {
 	// While the network churns on ListVersions() requests, statically analyze
 	// code from the current project.
 	ptree, err := p.ParseRootPackageTree()
@@ -755,14 +882,10 @@ func runStatusAll(ctx *dep.Ctx, out outputter, p *dep.Project, sm gps.SourceMana
 		// complete picture of all deps. That eliminates the need for at least
 		// some checks.
 
-		if err := out.BasicHeader(); err != nil {
-			return false, 0, err
-		}
-
 		logger.Println("Checking upstream projects:")
 
-		// BasicStatus channel to collect all the BasicStatus.
-		bsCh := make(chan *BasicStatus, len(slp))
+		// DetailStatus channel to collect all the DetailStatus.
+		dsCh := make(chan *DetailStatus, len(slp))
 
 		// Error channels to collect different errors.
 		errListPkgCh := make(chan error, len(slp))
@@ -865,14 +988,23 @@ func runStatusAll(ctx *dep.Ctx, out outputter, p *dep.Project, sm gps.SourceMana
 					}
 				}
 
-				bsCh <- &bs
+				ds := DetailStatus{
+					BasicStatus: bs,
+				}
+
+				if cmd.detail {
+					ds.Source = proj.Ident().Source
+					ds.Packages = proj.Packages()
+				}
+
+				dsCh <- &ds
 
 				wg.Done()
 			}(proj)
 		}
 
 		wg.Wait()
-		close(bsCh)
+		close(dsCh)
 		close(errListPkgCh)
 		close(errListVerCh)
 
@@ -909,23 +1041,30 @@ func runStatusAll(ctx *dep.Ctx, out outputter, p *dep.Project, sm gps.SourceMana
 			}
 		}
 
-		// A map of ProjectRoot and *BasicStatus. This is used in maintain the
-		// order of BasicStatus in output by collecting all the BasicStatus and
-		// then using them in order.
-		bsMap := make(map[string]*BasicStatus)
-		for bs := range bsCh {
-			bsMap[bs.ProjectRoot] = bs
-		}
+		if cmd.detail {
+			// A map of ProjectRoot and *DetailStatus. This is used in maintain the
+			// order of DetailStatus in output by collecting all the DetailStatus and
+			// then using them in order.
+			dsMap := make(map[string]*DetailStatus)
+			for ds := range dsCh {
+				dsMap[ds.ProjectRoot] = ds
+			}
 
-		// Use the collected BasicStatus in outputter.
-		for _, proj := range slp {
-			if err := out.BasicLine(bsMap[string(proj.Ident().ProjectRoot)]); err != nil {
+			if err := detailOutputAll(out, slp, dsMap, &p.Lock.SolveMeta); err != nil {
 				return false, 0, err
 			}
-		}
+		} else {
+			// A map of ProjectRoot and *BasicStatus. This is used in maintain the
+			// order of BasicStatus in output by collecting all the BasicStatus and
+			// then using them in order.
+			bsMap := make(map[string]*BasicStatus)
+			for bs := range dsCh {
+				bsMap[bs.ProjectRoot] = &bs.BasicStatus
+			}
 
-		if footerErr := out.BasicFooter(); footerErr != nil {
-			return false, 0, footerErr
+			if err := basicOutputAll(out, slp, bsMap); err != nil {
+				return false, 0, err
+			}
 		}
 
 		return false, errCount, err
@@ -1000,6 +1139,50 @@ outer:
 	return hasMissingPkgs, 0, errInputDigestMismatch
 }
 
+// basicOutputAll takes an outputter, a project list, and a map of ProjectRoot to *BasicStatus and
+// uses the outputter to output basic header, body lines (in the order of the project list), and
+// footer based on the project information.
+func basicOutputAll(out outputter, slp []gps.LockedProject, bsMap map[string]*BasicStatus) (err error) {
+	if err := out.BasicHeader(); err != nil {
+		return err
+	}
+
+	// Use the collected BasicStatus in outputter.
+	for _, proj := range slp {
+		if err := out.BasicLine(bsMap[string(proj.Ident().ProjectRoot)]); err != nil {
+			return err
+		}
+	}
+
+	if footerErr := out.BasicFooter(); footerErr != nil {
+		return footerErr
+	}
+
+	return nil
+}
+
+// detailOutputAll takes an outputter, a project list, and a map of ProjectRoot to *DetailStatus and
+// uses the outputter to output detailed header, body lines (in the order of the project list), and
+// footer based on the project information.
+func detailOutputAll(out outputter, slp []gps.LockedProject, dsMap map[string]*DetailStatus, metadata *dep.SolveMeta) (err error) {
+	if err := out.DetailHeader(metadata); err != nil {
+		return err
+	}
+
+	// Use the collected BasicStatus in outputter.
+	for _, proj := range slp {
+		if err := out.DetailLine(dsMap[string(proj.Ident().ProjectRoot)]); err != nil {
+			return err
+		}
+	}
+
+	if footerErr := out.DetailFooter(metadata); footerErr != nil {
+		return footerErr
+	}
+
+	return nil
+}
+
 func formatVersion(v gps.Version) string {
 	if v == nil {
 		return ""
@@ -1015,6 +1198,40 @@ func formatVersion(v gps.Version) string {
 		return r
 	}
 	return v.String()
+}
+
+func formatDetailVersion(v gps.Version, r gps.Revision) rawDetailVersion {
+	if v == nil {
+		return rawDetailVersion{
+			Revision: r.String(),
+		}
+	}
+	switch v.Type() {
+	case gps.IsBranch:
+		return rawDetailVersion{
+			Branch:   v.String(),
+			Revision: r.String(),
+		}
+	case gps.IsRevision:
+		return rawDetailVersion{
+			Revision: v.String(),
+		}
+	}
+
+	return rawDetailVersion{
+		Version:  v.String(),
+		Revision: r.String(),
+	}
+}
+
+func formatDetailLatestVersion(v gps.Version, hasError bool) rawDetailVersion {
+	if hasError {
+		return rawDetailVersion{
+			Revision: "unknown",
+		}
+	}
+
+	return formatDetailVersion(v, "")
 }
 
 // projectConstraint stores ProjectRoot and Constraint for that project.


### PR DESCRIPTION
Enhance `dep status` to support detailed output for the tabular, JSON, and `text/template` output formats. For each of these formats, the detailed output includes `source` repository information and a list of packages (instead of simply the count). For the JSON and `text/template` output formats, this detailed view separates branch, version, and revision information (for both locked and latest) to simplify programmatic processing of the output. For the JSON format, solve metadata is included in the output.

Additionally, this sets the stage for an all-at-once `text/template` outputter (like the JSON outputter, instead of the current line-by-line approach preserved from the basic `text/template` outputter) to allow a template to additionally process metadata information.